### PR TITLE
Build newer SeaBIOS

### DIFF
--- a/Makefile.stubdom
+++ b/Makefile.stubdom
@@ -6,6 +6,7 @@ SHELL := bash
 
 VMLINUZ=build/linux/arch/x86/boot/bzImage
 ROOTFS_IMG=build/rootfs/stubdom-linux-rootfs
+SEABIOS=build/qemu/roms/seabios/builds/seabios-256k/bios.bin
 
 # Stubdom disk content
 STUBDOM_DISK_FILE= \
@@ -116,6 +117,9 @@ build/qemu/i386-softmmu/qemu-system-i386: build/qemu/.patched build/qemu/config.
 	$(MAKE) -C build/qemu/pc-bios/optionrom linuxboot.bin
 	$(MAKE) -C build/qemu
 
+$(SEABIOS): build/qemu/.patched
+	$(MAKE) -C build/qemu/roms build-seabios-config-seabios-256k
+
 LINUX_PATCHES := $(shell $Q -l linux)
 
 build/linux/.extracted: dl/linux-$(LINUX_VERSION).tar.xz
@@ -157,9 +161,10 @@ export DRACUT_INSTALL
 $(ROOTFS_IMG): rootfs/gen $(STUBDOM_DISK_FILE)
 	env -u MAKELEVEL -u MAKEFLAGS -u MFLAGS ./$<
 
-install: $(VMLINUZ) $(ROOTFS_IMG)
+install: $(VMLINUZ) $(ROOTFS_IMG) $(SEABIOS)
 	install -D -m 444 $(VMLINUZ) $(DESTDIR)/usr/lib/xen/boot/stubdom-linux-kernel
 	install -m 444 $(ROOTFS_IMG) $(DESTDIR)/usr/lib/xen/boot/
+	install -m 444 $(SEABIOS) $(DESTDIR)/usr/lib/xen/boot/seabios-256k.bin
 
 clean:
 	rm -rf build

--- a/Makefile.stubdom
+++ b/Makefile.stubdom
@@ -112,7 +112,7 @@ build/qemu/config.status: build/qemu/.patched
 		--prefix=
 
 build/qemu/i386-softmmu/qemu-system-i386: build/qemu/.patched build/qemu/config.status build/qemu/.gui-agent-copied-in
-	$(MAKE) -C build/qemu/roms seavgabios-{cirrus,stdvga} efi-rom-rtl8139
+	$(MAKE) -C build/qemu/roms seavgabios-{cirrus,stdvga}
 	$(MAKE) -C build/qemu/pc-bios/optionrom linuxboot.bin
 	$(MAKE) -C build/qemu
 

--- a/Makefile.stubdom
+++ b/Makefile.stubdom
@@ -2,6 +2,8 @@ include Makefile.vars
 
 .PHONY: all install clean
 
+SHELL := bash
+
 VMLINUZ=build/linux/arch/x86/boot/bzImage
 ROOTFS_IMG=build/rootfs/stubdom-linux-rootfs
 
@@ -22,6 +24,7 @@ build/qemu/.extracted: dl/qemu-$(QEMU_VERSION).tar.xz
 	rm -rf build/qemu
 	mkdir -p build/qemu
 	tar -C build/qemu --strip-components=1 -xf $<
+	rm build/qemu/pc-bios/*.{rom,bin,dtb} # remove prebuild binaries
 	touch $@
 
 build/qemu/.patched: build/qemu/.extracted qemu/patches/series $(QEMU_PATCHES)
@@ -103,11 +106,14 @@ build/qemu/config.status: build/qemu/.patched
 		--disable-opengl \
 		--disable-virglrenderer \
 		--disable-xfsctl \
+		--disable-blobs \
 		--cxx=/non-existent \
 		--extra-cflags="-DXEN_PT_LOGGING_ENABLED=1" \
 		--prefix=
 
 build/qemu/i386-softmmu/qemu-system-i386: build/qemu/.patched build/qemu/config.status build/qemu/.gui-agent-copied-in
+	$(MAKE) -C build/qemu/roms seavgabios-{cirrus,stdvga} efi-rom-rtl8139
+	$(MAKE) -C build/qemu/pc-bios/optionrom linuxboot.bin
 	$(MAKE) -C build/qemu
 
 LINUX_PATCHES := $(shell $Q -l linux)

--- a/qemu/patches/disable-nic-option-rom.patch
+++ b/qemu/patches/disable-nic-option-rom.patch
@@ -1,0 +1,10 @@
+--- a/hw/net/rtl8139.c
++++ b/hw/net/rtl8139.c
+@@ -3472,7 +3472,6 @@ static void rtl8139_class_init(ObjectCla
+ 
+     k->realize = pci_rtl8139_realize;
+     k->exit = pci_rtl8139_uninit;
+-    k->romfile = "efi-rtl8139.rom";
+     k->vendor_id = PCI_VENDOR_ID_REALTEK;
+     k->device_id = PCI_DEVICE_ID_REALTEK_8139;
+     k->revision = RTL8139_PCI_REVID; /* >=0x20 is for 8139C+ */

--- a/qemu/patches/series
+++ b/qemu/patches/series
@@ -8,3 +8,4 @@ fw_cfg-init.patch
 153eba47-ACPI-don-t-call-acpi_pcihp_device_plug_cb-on-xen.patch
 round-pci-region-sizes.patch
 6c808651-xen-platform-Cleanup-network-infrastructure-when-emu.patch
+disable-nic-option-rom.patch

--- a/rootfs/gen
+++ b/rootfs/gen
@@ -53,9 +53,11 @@ do
 done
 make DESTDIR="$PWD/build/qemu/install" -C build/qemu install
 inst build/qemu/install/bin/qemu-system-i386 /bin/qemu
-for i in vgabios-{cirrus,stdvga}.bin efi-rtl8139.rom linuxboot.bin; do
-    inst build/qemu/install/share/qemu/$i /share/qemu/$i
-done
+inst build/qemu/pc-bios/optionrom/linuxboot.bin /share/qemu/linuxboot.bin
+inst build/qemu/pc-bios/vgabios-cirrus.bin /share/qemu/vgabios-cirrus.bin
+inst build/qemu/pc-bios/vgabios-stdvga.bin /share/qemu/vgabios-stdvga.bin
+inst build/qemu/pc-bios/efi-rtl8139.rom /share/qemu/efi-rtl8139.rom
+
 inst "/usr/bin/xenstore-read" "/bin/xenstore-read"
 inst "/usr/bin/xenstore-write" "/bin/xenstore-write"
 

--- a/rootfs/gen
+++ b/rootfs/gen
@@ -56,7 +56,6 @@ inst build/qemu/install/bin/qemu-system-i386 /bin/qemu
 inst build/qemu/pc-bios/optionrom/linuxboot.bin /share/qemu/linuxboot.bin
 inst build/qemu/pc-bios/vgabios-cirrus.bin /share/qemu/vgabios-cirrus.bin
 inst build/qemu/pc-bios/vgabios-stdvga.bin /share/qemu/vgabios-stdvga.bin
-inst build/qemu/pc-bios/efi-rtl8139.rom /share/qemu/efi-rtl8139.rom
 
 inst "/usr/bin/xenstore-read" "/bin/xenstore-read"
 inst "/usr/bin/xenstore-write" "/bin/xenstore-write"

--- a/rpm_spec/xen-hvm-stubdom-linux.spec
+++ b/rpm_spec/xen-hvm-stubdom-linux.spec
@@ -53,6 +53,7 @@ make -f Makefile.stubdom DESTDIR=${RPM_BUILD_ROOT} install
 %files
 /usr/lib/xen/boot/stubdom-linux-rootfs
 /usr/lib/xen/boot/stubdom-linux-kernel
+/usr/lib/xen/boot/seabios-256k.bin
 
 
 %changelog

--- a/rpm_spec/xen-hvm-stubdom-linux.spec
+++ b/rpm_spec/xen-hvm-stubdom-linux.spec
@@ -22,6 +22,7 @@ BuildRequires: xen-devel
 BuildRequires: glib2-devel
 BuildRequires: autoconf
 BuildRequires: automake
+BuildRequires: edk2-tools
 
 # QEMU Qubes gui-agent
 BuildRequires: qubes-gui-common-devel


### PR DESCRIPTION
The 'mptsas1068' controller seems to work fine with Linux and Windows (QubesOS/qubes-issues#3068) but needs a newer SeaBIOS than shipped with Fedora 25.