### PR TITLE
qemu: Use machine BDF when cheking for IGDs

### DIFF
--- a/qemu/patches/stubdom-pci-addr-fix.patch
+++ b/qemu/patches/stubdom-pci-addr-fix.patch
@@ -11,6 +11,17 @@
      s->is_virtfn = s->real_device.is_virtfn;
      if (s->is_virtfn) {
          XEN_PT_LOG(d, "%04x:%02x:%02x.%d is a SR-IOV Virtual Function\n",
+@@ -804,8 +808,8 @@ static void xen_pt_realize(PCIDevice *d,
+     s->io_listener = xen_pt_io_listener;
+ 
+     /* Setup VGA bios for passthrough GFX */
+-    if ((s->real_device.domain == 0) && (s->real_device.bus == 0) &&
+-        (s->real_device.dev == 2) && (s->real_device.func == 0)) {
++    if ((s->machine_addr.domain == 0) && (s->machine_addr.bus == 0) &&
++        (s->machine_addr.slot == 2) && (s->machine_addr.function == 0)) {
+         if (!is_igd_vga_passthrough(&s->real_device)) {
+             error_setg(errp, "Need to enable igd-passthru if you're trying"
+                     " to passthrough IGD GFX");
 @@ -936,6 +940,7 @@ static void xen_pt_unregister_device(PCI
  
  static Property xen_pci_passthrough_properties[] = {


### PR DESCRIPTION
The check for graphic card pass-through assumes that it sees the real
BDF but when running inside a stubdom BDF 0000:00:02.0 is simply the
third passed-through device. So use the machine BDF instead of the
pcifront BDF.

QubesOS/qubes-issues#3263