### PR TITLE
README: Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Building
    - python
    - zlib-devel
    - xen-devel
-   - xen-devel
    - glib2-devel
    - autoconf
    - automake
@@ -22,13 +21,18 @@ Building
    - libseccomp-devel >= 2.3.0
    - pixman-devel
    - xen-devel
+   - qubes-gui-common-devel
+   - qubes-libvchan-xen-devel
 
    - bc
    - gcc-plugin-devel
+   - gcc-c++
+   - quilt
 
    - xen-runtime
    - busybox
    - dracut
+   - inotify-tools
 
 2. Build the thing:
 


### PR DESCRIPTION
quilt is needed to apply patches.
gcc-c++ is needed by the linux gcc-plugins.
xen-devel is listed twice, so remove the extra.
gui-agent needs the libvchan.h and qubes-gui-protocol.h headers.
inotify-tools is needed for the inotifywait command.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>