### PR TITLE
Search for kernel on xvdd only if -append qemu option is used

### DIFF
--- a/rootfs/init
+++ b/rootfs/init
@@ -53,7 +53,7 @@ device_model="device-model/$target"
 mkdir /tmp/qmp
 
 kernel=
-if [ -b /dev/xvdd ]; then
+if echo "$dm_args" | grep -q '^-append' && [ -b /dev/xvdd ]; then
     mkdir /tmp/boot
     mount /dev/xvdd /tmp/boot -o ro
     if [ -f /tmp/boot/vmlinuz ]; then


### PR DESCRIPTION
xvdd can be used also for bootable CDROM or another attached disk, if no
dom0-provided kernel is used. Mount xvdd only if dom0-provided kernel is
used and detect it based on -append qemu option presence (kernel options
are there only if kernel is given by dom0).