### PR TITLE
Add "/lib" to ldconfig arguments

### DIFF
--- a/rootfs/gen
+++ b/rootfs/gen
@@ -93,7 +93,7 @@ done
 unset IFS
 mv $rootfs_dir/lib{.new,}
 touch $rootfs_dir/etc/ld.so.conf
-/sbin/ldconfig -r $rootfs_dir
+/sbin/ldconfig -r $rootfs_dir /lib
 ln -s lib $rootfs_dir/lib64
 
 find "$rootfs_dir" -print0 | xargs -0 touch -ch -d @0


### PR DESCRIPTION
On some 64bit distributions ldconfig does not consider /lib a "trusted
directory" to be checked when creating links. Adding this option makes
sure needed symlinks will be created in /lib rootfs directory.