### PR TITLE
Adjust for Xen 4.14

### DIFF
--- a/Makefile.stubdom
+++ b/Makefile.stubdom
@@ -280,8 +280,8 @@ $(ROOTFS_IMG): rootfs/gen $(STUBDOM_DISK_FILE)
 	env -u MAKELEVEL -u MAKEFLAGS -u MFLAGS ./$<
 
 install: $(VMLINUZ) $(ROOTFS_IMG)
-	install -D -m 444 $(VMLINUZ) $(DESTDIR)$(STUBDOM_BINDIR)/stubdom-linux-kernel
-	install -m 444 $(ROOTFS_IMG) $(DESTDIR)$(STUBDOM_BINDIR)/
+	install -D -m 444 $(VMLINUZ) $(DESTDIR)$(STUBDOM_BINDIR)/qemu-stubdom-linux-kernel
+	install -D -m 444 $(ROOTFS_IMG) $(DESTDIR)$(STUBDOM_BINDIR)/qemu-stubdom-linux-rootfs
 
 clean:
 	rm -rf build

--- a/rootfs/init
+++ b/rootfs/init
@@ -16,7 +16,7 @@ domid=$(/bin/xenstore-read "target")
 vm_path=$(xenstore-read "/local/domain/$domid/vm")
 # convert multiple keys into \n separated arguments, as shell doesn't handle
 # NUL well
-dm_args=$(xenstore-read $(xenstore-list -p "$vm_path/image/dmargs"|sort))
+dm_args=$(xenstore-read $(xenstore-list -p "$vm_path/image/dm-argv"|sort))
 
 # add audiodev conf to cmdline and run pulseaudio 
 audio_model=$(echo "$dm_args" | sed -n '/^-soundhw/ {n;p}')
@@ -128,6 +128,10 @@ while read -r line; do
     fi
 done < /proc/kmsg
 ) &
+
+# replace $STUBDOM_RESTORE_INCOMING_ARG with argument for incoming state - if
+# applicable
+dm_args=$(echo "$dm_args" | sed 's/\$STUBDOM_RESTORE_INCOMING_ARG/fd:3/')
 
 # setup FD 3 and 4 for migration stream (incoming, outgoing), actual qemu
 # options are controlled by the toolstack

--- a/rpm_spec/xen-hvm-stubdom-linux.spec.in
+++ b/rpm_spec/xen-hvm-stubdom-linux.spec.in
@@ -12,7 +12,7 @@ Group: System
 License: GPL
 URL: https://www.qubes-os.org/
 
-Requires: xen-libs >= 2001:4.12.0~rc1-0
+Requires: xen-libs >= 2001:4.14.0
 
 BuildRequires: quilt
 
@@ -89,8 +89,8 @@ make -f Makefile.stubdom DESTDIR=${RPM_BUILD_ROOT} STUBDOM_BINDIR=/usr/libexec/x
 
 
 %files
-/usr/libexec/xen/boot/stubdom-linux-rootfs
-/usr/libexec/xen/boot/stubdom-linux-kernel
+/usr/libexec/xen/boot/qemu-stubdom-linux-rootfs
+/usr/libexec/xen/boot/qemu-stubdom-linux-kernel
 
 
 %changelog


### PR DESCRIPTION
- different qemu arguments handling in an upstream-accepted version
- different binaries name