### PR TITLE
init: Use /proc/self/fd to refer to FDs

### DIFF
--- a/rootfs/init
+++ b/rootfs/init
@@ -155,14 +155,14 @@ qemu_pid=$!
 
 
 while [ ! -e /tmp/qemu.qmp ]; do sleep 0.1; done
-if [ -e /dev/fd/4 ]; then
+if [ -e /proc/self/fd/4 ]; then
     qmp_hello=$'{"execute":"qmp_capabilities","id":1}\r\n'
     qmp_addfd=$'{"execute":"add-fd", "arguments": { "fdset-id": 1 }, "id":42 }\r\n'
     add-fd /tmp/qemu.qmp /dev/fd/4 "$qmp_hello$qmp_addfd" "42"
     exec 4>&-
 fi
 
-if [ -e /dev/fd/3 ]; then
+if [ -e /proc/self/fd/3 ]; then
     exec 3<&-
 fi
 


### PR DESCRIPTION
This is untested in Qubes, but I tested similar in vanilla xen.

/dev/fd is a symlink to /proc/self/fd, typically created by udev, and
does not exist in the initramfs.  Switch to using /proc/self/fd directly
so that the existence tests can succeed.  Without this, suspend cannot
work since fdset-id 1 will not be available in qemu.

The other option would be to create the symlink, but busybox doesn't include `ln` at this time.

There is a mismatch now since add-fd still takes /dev/fd as an argument.