### PR TITLE
qemu: fix TOLUD for PCI passthrough

### DIFF
--- a/qemu/patches/Fix-TOLUD-for-PCI-passthroughed-devices.patch
+++ b/qemu/patches/Fix-TOLUD-for-PCI-passthroughed-devices.patch
@@ -1,0 +1,105 @@
+From ea9ab4a423dbff7d20b1fa510aac440391935474 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mateusz=20Pi=C3=B3rkowski?= <mati7337@protonmail.ch>
+Date: Sat, 26 Mar 2022 03:06:35 +0100
+Subject: [PATCH] Fix TOLUD for PCI passthroughed devices
+
+---
+ hw/i386/xen/xen-hvm.c | 73 ++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 72 insertions(+), 1 deletion(-)
+
+diff --git a/hw/i386/xen/xen-hvm.c b/hw/i386/xen/xen-hvm.c
+index 9b432773f0..78c6bd758d 100644
+--- a/hw/i386/xen/xen-hvm.c
++++ b/hw/i386/xen/xen-hvm.c
+@@ -198,6 +198,65 @@ qemu_irq *xen_interrupt_controller_init(void)
+ 
+ /* Memory Ops */
+ 
++struct iomem_entry{
++    uint64_t addr_start;
++    uint64_t addr_end;
++    uint64_t name_len;
++    char *name;
++};
++
++int parse_iomem_entry(char *line, struct iomem_entry *entry)
++{
++    uint64_t pos = 0;
++
++    if (sscanf(line, "%llx-%llx : %lln", &entry->addr_start, &entry->addr_end, &pos) != 2) {
++        return -1;
++    }
++    entry->name = line + pos;
++    if (sscanf(line+pos, "%*s%lln\n", &entry->name_len) != 0) {
++        return -1;
++    }
++
++    return 0;
++}
++
++uint64_t get_min_pci_addr(void)
++{
++    FILE *iomem = fopen("/proc/iomem", "r");
++    if (iomem == NULL) {
++        return 0;
++    }
++
++    uint64_t iomem_line_bufsize = 128;
++    char *iomem_line = (char *)malloc(iomem_line_bufsize * sizeof(char));
++    if (iomem_line == NULL) {
++        fclose(iomem);
++        return 0;
++    }
++
++    uint64_t min_addr = 0;
++
++    while (getline(&iomem_line, &iomem_line_bufsize,iomem) != -1) {
++        struct iomem_entry entry;
++        if (parse_iomem_entry(iomem_line, &entry) != 0) {
++            continue;
++        }
++
++        uint64_t chars_match = 0;
++        if (sscanf(entry.name, "%*llx:%*llx:%*llx.%*llx%lln", &chars_match) != 0) {
++            break;
++        } else if (chars_match == entry.name_len) {
++            min_addr = entry.addr_start;
++            break;
++        }
++    }
++
++    free(iomem_line);
++    fclose(iomem);
++    return min_addr;
++}
++
++
+ static void xen_ram_init(PCMachineState *pcms,
+                          ram_addr_t ram_size, MemoryRegion **ram_memory_p)
+ {
+@@ -211,9 +270,21 @@ static void xen_ram_init(PCMachineState *pcms,
+ 
+     /* Handle the machine opt max-ram-below-4g.  It is basically doing
+      * min(xen limit, user limit).
++     *
++     * xen limit is calculated based on the min address of PCI devices
++     *
++     * TODO: hvmloader seems to relocate memory which overlaps with
++     * PCI addresses, but for some reason that doesn't work and it's
++     * required to lower max-ram-below-4g. Fixing that might solve the
++     * problem in a more elegant way.
+      */
+     if (!user_lowmem) {
+-        user_lowmem = HVM_BELOW_4G_RAM_END; /* default */
++        uint64_t min_pci_addr = get_min_pci_addr();
++        if (min_pci_addr && min_pci_addr < HVM_BELOW_4G_RAM_END) {
++            user_lowmem = min_pci_addr;
++        } else {
++            user_lowmem = HVM_BELOW_4G_RAM_END;
++        }
+     }
+     if (HVM_BELOW_4G_RAM_END <= user_lowmem) {
+         user_lowmem = HVM_BELOW_4G_RAM_END;
+-- 
+2.34.1
+

--- a/qemu/patches/series
+++ b/qemu/patches/series
@@ -18,3 +18,4 @@
 0018-pc-bios-ignore-prebuilt-binaries.patch
 seabios-python3.patch
 vgasrc-ignore-.node.gnu.property-binutils-2.36-suppo.patch
+Fix-TOLUD-for-PCI-passthroughed-devices.patch


### PR DESCRIPTION
By default qemu sets the top of low usable DRAM to 3.75G which isn't
enough for larger BARs in most GPUs. hvmloader seems to try relocating
memory which overlaps with PCI addresses, but for some reason it doesn't
work. Too low TOLUD also causes problems as VMs crash while starting with
logs indicating a problem with qemu's emulated ehci hc.

This patch solves this problem by setting TOLUD to accomodate the lowest
address of a PCI device attached to the stubdomain.

fixes QubesOS/qubes-issues#4321