### PR TITLE
Fix unitialized variable causing PCI passthrough to fail

### DIFF
--- a/qemu/patches/0019-hw-xen-xen_pt-fix-uninitialized-variable.patch
+++ b/qemu/patches/0019-hw-xen-xen_pt-fix-uninitialized-variable.patch
@@ -1,0 +1,39 @@
+From d0d57c9e02764687f412b00e90e1a61d73e58605 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Fri, 27 Jan 2023 05:55:55 +0100
+Subject: [PATCH] hw/xen/xen_pt: fix uninitialized variable
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+xen_pt_config_reg_init() reads only that many bytes as the size of the
+register that is being initialized. It uses
+xen_host_pci_get_{byte,word,long} and casts its last argument to
+expected pointer type. This means for smaller registers higher bits of
+'val' are not initialized. Then, the function fails if any of those
+higher bits are set.
+
+Fix this by initializing 'val' with zero.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ hw/xen/xen_pt_config_init.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hw/xen/xen_pt_config_init.c b/hw/xen/xen_pt_config_init.c
+index cde898b744..8b9b554352 100644
+--- a/hw/xen/xen_pt_config_init.c
++++ b/hw/xen/xen_pt_config_init.c
+@@ -1924,7 +1924,7 @@ static void xen_pt_config_reg_init(XenPCIPassthroughState *s,
+     if (reg->init) {
+         uint32_t host_mask, size_mask;
+         unsigned int offset;
+-        uint32_t val;
++        uint32_t val = 0;
+ 
+         /* initialize emulate register */
+         rc = reg->init(s, reg_entry->reg,
+-- 
+2.37.3
+

--- a/qemu/patches/series
+++ b/qemu/patches/series
@@ -16,6 +16,7 @@
 0016-IGD-improve-legacy-vbios-handling.patch
 0017-IGD-move-enabling-opregion-access-to-libxl.patch
 0018-pc-bios-ignore-prebuilt-binaries.patch
+0019-hw-xen-xen_pt-fix-uninitialized-variable.patch
 seabios-python3.patch
 vgasrc-ignore-.node.gnu.property-binutils-2.36-suppo.patch
 qemu-stub-xengt-support.patch


### PR DESCRIPTION
This started to manifest itself under Fedora 37, likely due to the
compiler version.

QubesOS/qubes-issues#6982