### PR TITLE
Wait for pulseaudio startup

### DIFF
--- a/rootfs/init
+++ b/rootfs/init
@@ -160,6 +160,13 @@ while read -r line; do
 done < /proc/kmsg
 ) &
 
+# wait for pulseaudio startup just before starting qemu
+if [ -n "$audio_model" ]; then
+    while ! PULSE_SERVER=unix:/tmp/pa.sock pactl info >/dev/null; do
+        sleep 0.01
+    done
+fi
+
 # replace $STUBDOM_RESTORE_INCOMING_ARG with argument for incoming state - if
 # applicable
 dm_args=$(echo "$dm_args" | sed 's/\$STUBDOM_RESTORE_INCOMING_ARG/fd:3/')


### PR DESCRIPTION
If PulseAudio starts slowly, QEMU may try to connect to it when it
doesn't accept incoming connections yet, and cause QEMU fail to start.
Wait for PA startup (when relevant), but only just before QEMU startup -
this allows parallel PA startup with other init tasks (network setup
etc).

Fixes QubesOS/qubes-issues#9540