### PR TITLE
Extend IGD check

### DIFF
--- a/qemu/patches/0021-hw-xen-consider-PCI_CLASS_DISPLAY_OTHER-for-IGD-too.patch
+++ b/qemu/patches/0021-hw-xen-consider-PCI_CLASS_DISPLAY_OTHER-for-IGD-too.patch
@@ -1,0 +1,34 @@
+From ea4ce16501810c70c71f63f680eda64288b2c7fd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Thu, 28 Nov 2024 12:53:48 +0100
+Subject: [PATCH] hw/xen: consider PCI_CLASS_DISPLAY_OTHER for IGD too
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Graphics card at least on Raptor Lake has class PCI_CLASS_DISPLAY_OTHER,
+update the check function to match this.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ include/hw/xen/xen_igd.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/include/hw/xen/xen_igd.h b/include/hw/xen/xen_igd.h
+index 7ffca06c10..0a7917a6f4 100644
+--- a/include/hw/xen/xen_igd.h
++++ b/include/hw/xen/xen_igd.h
+@@ -27,7 +27,8 @@ void xen_igd_passthrough_isa_bridge_create(XenPCIPassthroughState *s,
+ static inline bool is_igd_vga_passthrough(XenHostPCIDevice *dev)
+ {
+     return (xen_igd_gfx_pt_enabled()
+-            && ((dev->class_code >> 0x8) == PCI_CLASS_DISPLAY_VGA));
++            && ((dev->class_code >> 0x8) == PCI_CLASS_DISPLAY_VGA
++                || (dev->class_code >> 0x8) == PCI_CLASS_DISPLAY_OTHER));
+ }
+ 
+ #endif
+-- 
+2.46.0
+

--- a/qemu/patches/series
+++ b/qemu/patches/series
@@ -15,6 +15,7 @@
 0018-IGD-move-enabling-opregion-access-to-libxl.patch
 0019-pc-bios-ignore-prebuilt-binaries.patch
 0020-Add-stubdom-xengt-support.patch
+0021-hw-xen-consider-PCI_CLASS_DISPLAY_OTHER-for-IGD-too.patch
 seabios-python3.patch
 seabios-svgamodes-Add-all-HD-and-QXGA-resolutions.patch
 power_mgmt.patch


### PR DESCRIPTION
Consider also "Display controller" an IGD, not only "VGA compatible
controller". Specifically, IGD on Raptor Lake has 0x038000 class, not
0x030000.